### PR TITLE
Prevent NullPointerException that rarely happens

### DIFF
--- a/src/main/java/nukkitcoders/mobplugin/entities/WalkingEntity.java
+++ b/src/main/java/nukkitcoders/mobplugin/entities/WalkingEntity.java
@@ -50,7 +50,7 @@ public abstract class WalkingEntity extends BaseEntity {
         double near = Integer.MAX_VALUE;
 
         for (Entity entity : this.getLevel().getEntities()) {
-            if (entity == this || !(entity instanceof EntityCreature) || !this.canTarget(entity)) {
+            if (entity == null || entity == this || !(entity instanceof EntityCreature) || !this.canTarget(entity)) {
                 continue;
             }
 


### PR DESCRIPTION
Prevent NullPointerException that rarely happens.

Occasionally, some plugins immediately remove entities, causing MobPlugin NullPointerException errors.